### PR TITLE
Changed the Look of the Answer Buttons

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
     <title>MathBeast</title>
     <meta name="description" content="Math game">
 
-    <link href="js/lib/bootstrap/css/bootstrap.min.css" rel="stylesheet" media="all">
+    <link href="js/lib/bootstrap/css/bootstrap.css" rel="stylesheet" media="all">
     <link href="js/lib/jquery-ui/jquery-ui.min.css" rel="stylesheet" media="all">
     <link href="js/lib/jquery-ui/jquery-ui.theme.min.css" rel="stylesheet" media="all">
     <link href="css/style.css" rel="stylesheet" media="all">

--- a/js/lib/bootstrap/css/bootstrap.css
+++ b/js/lib/bootstrap/css/bootstrap.css
@@ -2987,10 +2987,10 @@ select[multiple].form-group-lg .form-control {
   }
 }
 .btn {
-  display: inline-block;
+  display: block;
   padding: 6px 12px;
   margin-bottom: 0;
-  font-size: 14px;
+  font-size: 30px;
   font-weight: normal;
   line-height: 1.42857143;
   text-align: center;
@@ -3042,7 +3042,7 @@ fieldset[disabled] .btn {
 }
 .btn-default {
   color: #333;
-  background-color: #fff;
+  background-color: #99D6AD;
   border-color: #ccc;
 }
 .btn-default:hover,
@@ -3052,7 +3052,7 @@ fieldset[disabled] .btn {
 .btn-default.active,
 .open > .dropdown-toggle.btn-default {
   color: #333;
-  background-color: #e6e6e6;
+  background-color: #009933;
   border-color: #adadad;
 }
 .btn-default:active,

--- a/js/lib/bootstrap/css/bootstrap.css
+++ b/js/lib/bootstrap/css/bootstrap.css
@@ -2989,7 +2989,7 @@ select[multiple].form-group-lg .form-control {
 .btn {
   display: block;
   padding: 6px 12px;
-  margin-bottom: 0;
+  margin-bottom: 1em;
   font-size: 30px;
   font-weight: normal;
   line-height: 1.42857143;

--- a/js/lib/bootstrap/css/bootstrap.css
+++ b/js/lib/bootstrap/css/bootstrap.css
@@ -2988,7 +2988,7 @@ select[multiple].form-group-lg .form-control {
 }
 .btn {
   display: block;
-  padding: 6px 12px;
+  padding: 45px 12px;
   margin-bottom: 1em;
   font-size: 30px;
   font-weight: normal;

--- a/templates/MainView.html
+++ b/templates/MainView.html
@@ -20,14 +20,14 @@
     </section>
     <section class="answers">
       <div class="row">
-        <div class="col-xs-4 text-center">
-          <button id="answers--option-1" class="answer-option btn btn-default btn-lg"></button>
+        <div class="col-md-4 text-center">
+          <button id="answers--option-1" class="answer-option answer-button btn btn-default btn-block"></button>
         </div>
-        <div class="col-xs-4 text-center">
-          <button id="answers--option-2" class="answer-option btn btn-default btn-lg"></button>
+        <div class="col-md-4 text-center">
+          <button id="answers--option-2" class="answer-option answer-button btn btn-default btn-block"></button>
         </div>
-        <div class="col-xs-4 text-center">
-          <button id="answers--option-3" class="answer-option btn btn-default btn-lg"></button>
+        <div class="col-md-4 text-center">
+          <button id="answers--option-3" class="answer-option answer-button btn btn-default btn-block"></button>
         </div>
       </div><!-- End .row -->
     </section>


### PR DESCRIPTION
I realized that all the work I was doing wasn't showing up because we were using the minified file for bootstrap instead of bootstrap.css, so I changed that. We can always re-minify that code at the end before deployment. 

I also changed the color of the buttons (let me know if you'd like a diffrent color), along with the size of them. The buttons now appear in a row on a larger screen and in a column format on a smaller one. I was able to give them some margin on the bottom when they're in a column, but have yet to work out how to give them a left and right margin without breaking the bootstrap css.

Here's what it looks like:

<img width="377" alt="mathbeast capture" src="https://cloud.githubusercontent.com/assets/11987546/9426143/8d80fe72-48e2-11e5-946e-2858ea31281d.PNG">
